### PR TITLE
Add Flask demo for necrotizing fasciitis risk stratification

### DIFF
--- a/fascitis-app/.env
+++ b/fascitis-app/.env
@@ -1,0 +1,3 @@
+# Variables de entorno de ejemplo
+OPENAI_API_KEY=sk-tu-clave
+SECRET_KEY=cambia-esto

--- a/fascitis-app/app.py
+++ b/fascitis-app/app.py
@@ -1,0 +1,200 @@
+import os
+from math import exp
+from flask import Flask, render_template, request, flash, redirect, url_for
+from dotenv import load_dotenv
+
+try:
+    from openai import OpenAI
+except ImportError:  # openai es opcional
+    OpenAI = None
+
+load_dotenv()
+
+app = Flask(__name__)
+app.secret_key = os.getenv("SECRET_KEY", "dev")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+def clamp(value, min_value=0.0, max_value=1.0):
+    """Restringe value al rango [min_value, max_value]."""
+    return max(min_value, min(value, max_value))
+
+def sigmoid(x):
+    """Función sigmoide clásica."""
+    return 1 / (1 + exp(-x))
+
+def normalize_demo(value, max_value):
+    """Normaliza valores para el modelo DEMO."""
+    if max_value <= 0:
+        return 0
+    return clamp(value / max_value)
+
+def calculate_demo(pcr, wbc, esr):
+    """Calcula riesgo DEMO combinando PCR, leucocitos y VSG."""
+    npcr = normalize_demo(pcr, 300)
+    nwbc = normalize_demo(wbc, 40)
+    nesr = normalize_demo(esr, 150)
+    weights = [0.4, 0.35, 0.25]
+    z = npcr * weights[0] + nwbc * weights[1] + nesr * weights[2]
+    # Ajuste simple con sigmoide
+    return sigmoid(3 * z - 1.5)
+
+def calculate_lrinec(crp, wbc, hb, na, creat, glucose):
+    """Calcula puntaje LRINEC y lo mapea a probabilidad."""
+    score = 0
+    # CRP
+    if crp >= 150:
+        score += 4
+    # Leucocitos
+    if 15 <= wbc <= 25:
+        score += 1
+    elif wbc > 25:
+        score += 2
+    # Hemoglobina
+    if 11 <= hb <= 13.5:
+        score += 1
+    elif hb < 11:
+        score += 2
+    # Sodio
+    if na < 135:
+        score += 2
+    # Creatinina
+    if creat > 1.6:
+        score += 2
+    # Glucosa
+    if glucose > 180:
+        score += 1
+    # Probabilidad suave usando sigmoide centrado en 6.5
+    prob = sigmoid((score - 6.5) / 1.5)
+    if score >= 8:
+        level = "Alto"
+    elif score >= 6:
+        level = "Intermedio"
+    else:
+        level = "Bajo"
+    return score, level, prob
+
+def keywords_factor(text):
+    """Ajuste por palabras clave cuando no hay IA."""
+    keywords = [
+        "dolor desproporcionado",
+        "crepitación",
+        "bullas",
+        "necrosis",
+        "progresión rápida",
+        "sepsis",
+        "hipotensión",
+    ]
+    t = text.lower()
+    hits = sum(1 for kw in keywords if kw in t)
+    return clamp(0.05 * hits, 0, 0.3)
+
+def ai_text_factor(text):
+    """Obtiene factor textual [0,1] desde la API de OpenAI."""
+    if not (OPENAI_API_KEY and OpenAI):
+        return None
+    client = OpenAI(api_key=OPENAI_API_KEY)
+    prompt = (
+        "Devuelve SOLO un número entre 0 y 1 (máx 3 decimales) que represente "
+        "la probabilidad de fascitis necrotizante según el texto dado:\n" + text
+    )
+    try:
+        resp = client.responses.create(
+            model="gpt-3.5-turbo-instruct",
+            input=prompt,
+            max_tokens=5,
+            temperature=0,
+        )
+        value = resp.output_text.strip().replace(",", ".")
+        return clamp(float(value))
+    except Exception:
+        return None
+
+def combine_risk(base_prob, text_factor, ai_active):
+    if ai_active and text_factor is not None:
+        return clamp(0.7 * base_prob + 0.3 * text_factor)
+    elif text_factor:
+        return clamp(base_prob + text_factor)
+    return base_prob
+
+def risk_label(prob):
+    if prob >= 0.6:
+        return "Alto", "danger", "#dc3545"
+    if prob >= 0.3:
+        return "Intermedio", "warning", "#ffc107"
+    return "Bajo", "success", "#198754"
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    result = None
+    model = "demo"
+    lrinec_score = None
+    lrinec_level = None
+    form_values = {}
+    if request.method == "POST":
+        form_values = request.form.to_dict()
+        model = request.form.get("model", "demo")
+        text = request.form.get("notes", "")
+        try:
+            if model == "demo":
+                pcr = float(request.form.get("pcr", ""))
+                wbc = float(request.form.get("wbc", ""))
+                esr = float(request.form.get("esr", ""))
+                if min(pcr, wbc, esr) < 0:
+                    raise ValueError
+                base_prob = calculate_demo(pcr, wbc, esr)
+                inputs = {
+                    "PCR (mg/L)": pcr,
+                    "Leucocitos (×10⁹/L)": wbc,
+                    "VSG (mm/h)": esr,
+                }
+            else:
+                crp = float(request.form.get("crp", ""))
+                wbc = float(request.form.get("wbc", ""))
+                hb = float(request.form.get("hb", ""))
+                na = float(request.form.get("na", ""))
+                creat = float(request.form.get("creat", ""))
+                glucose = float(request.form.get("glucose", ""))
+                if min(crp, wbc, hb, na, creat, glucose) < 0:
+                    raise ValueError
+                lrinec_score, lrinec_level, base_prob = calculate_lrinec(
+                    crp, wbc, hb, na, creat, glucose
+                )
+                inputs = {
+                    "CRP (mg/L)": crp,
+                    "Leucocitos (×10⁹/L)": wbc,
+                    "Hemoglobina (g/dL)": hb,
+                    "Sodio (mmol/L)": na,
+                    "Creatinina (mg/dL)": creat,
+                    "Glucosa (mg/dL)": glucose,
+                }
+            ai_active = bool(OPENAI_API_KEY and OpenAI)
+            tfactor = ai_text_factor(text) if ai_active else keywords_factor(text)
+            final_prob = combine_risk(base_prob, tfactor, ai_active)
+            level, color_class, color_hex = risk_label(final_prob)
+            risk_percent = round(final_prob * 100, 1)
+            result = {
+                "prob": final_prob,
+                "percent": risk_percent,
+                "level": level,
+                "color_class": color_class,
+                "color_hex": color_hex,
+                "inputs": inputs,
+            }
+        except ValueError:
+            flash("Valores inválidos o negativos.")
+            return redirect(url_for("index"))
+        except KeyError:
+            flash("Faltan campos obligatorios.")
+            return redirect(url_for("index"))
+    return render_template(
+        "index.html",
+        result=result,
+        model=model,
+        lrinec_score=lrinec_score,
+        lrinec_level=lrinec_level,
+        form_values=form_values,
+        ai_active=bool(OPENAI_API_KEY and OpenAI),
+    )
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/fascitis-app/requirements.txt
+++ b/fascitis-app/requirements.txt
@@ -1,0 +1,3 @@
+Flask>=3.0,<4.0
+python-dotenv>=1.0,<2.0
+openai>=1.0,<2.0

--- a/fascitis-app/static/css/styles.css
+++ b/fascitis-app/static/css/styles.css
@@ -1,0 +1,14 @@
+body {
+  background-color: #f8f9fa;
+}
+.progress-circle {
+  --size: 150px;
+  width: var(--size);
+  height: var(--size);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: conic-gradient(var(--color) calc(var(--value)*1%), #e9ecef 0);
+  font-weight: bold;
+}

--- a/fascitis-app/static/img/hero.svg
+++ b/fascitis-app/static/img/hero.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#e9ecef"/>
+  <circle cx="100" cy="100" r="60" fill="#0d6efd" opacity="0.3"/>
+  <text x="100" y="110" text-anchor="middle" font-size="20" fill="#0d6efd">NF</text>
+</svg>

--- a/fascitis-app/templates/base.html
+++ b/fascitis-app/templates/base.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Calculadora Fascitis</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+  </head>
+  <body>
+    <div class="container py-4">
+      {% with messages = get_flashed_messages() %}
+      {% if messages %}
+      <div class="alert alert-warning">
+        {% for msg in messages %}
+          <div>{{ msg }}</div>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </div>
+    <footer class="text-center small text-muted py-3">
+      <p>Esta herramienta es educativa y no sustituye el juicio clínico.</p>
+    </footer>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  </body>
+</html>

--- a/fascitis-app/templates/index.html
+++ b/fascitis-app/templates/index.html
@@ -1,0 +1,91 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row g-4">
+  <div class="col-md-6">
+    <form method="post">
+      <div class="mb-3">
+        <label for="model" class="form-label">Modelo</label>
+        <select id="model" name="model" class="form-select">
+          <option value="demo" {% if model == 'demo' %}selected{% endif %}>DEMO</option>
+          <option value="lrinec" {% if model == 'lrinec' %}selected{% endif %}>LRINEC</option>
+        </select>
+      </div>
+      <div class="mb-3 demo-field">
+        <label class="form-label">PCR (mg/L)</label>
+        <input type="number" step="any" min="0" class="form-control" name="pcr" value="{{ form_values.get('pcr','') }}">
+      </div>
+      <div class="mb-3 demo-field">
+        <label class="form-label">Leucocitos (×10⁹/L)</label>
+        <input type="number" step="any" min="0" class="form-control" name="wbc" value="{{ form_values.get('wbc','') }}">
+      </div>
+      <div class="mb-3 demo-field">
+        <label class="form-label">VSG (mm/h)</label>
+        <input type="number" step="any" min="0" class="form-control" name="esr" value="{{ form_values.get('esr','') }}">
+      </div>
+      <div class="mb-3 lrinec-field">
+        <label class="form-label">CRP (mg/L)</label>
+        <input type="number" step="any" min="0" class="form-control" name="crp" value="{{ form_values.get('crp','') }}">
+      </div>
+      <div class="mb-3 lrinec-field">
+        <label class="form-label">Leucocitos (×10⁹/L)</label>
+        <input type="number" step="any" min="0" class="form-control" name="wbc" value="{{ form_values.get('wbc','') }}">
+      </div>
+      <div class="mb-3 lrinec-field">
+        <label class="form-label">Hemoglobina (g/dL)</label>
+        <input type="number" step="any" min="0" class="form-control" name="hb" value="{{ form_values.get('hb','') }}">
+      </div>
+      <div class="mb-3 lrinec-field">
+        <label class="form-label">Sodio (mmol/L)</label>
+        <input type="number" step="any" min="0" class="form-control" name="na" value="{{ form_values.get('na','') }}">
+      </div>
+      <div class="mb-3 lrinec-field">
+        <label class="form-label">Creatinina (mg/dL)</label>
+        <input type="number" step="any" min="0" class="form-control" name="creat" value="{{ form_values.get('creat','') }}">
+      </div>
+      <div class="mb-3 lrinec-field">
+        <label class="form-label">Glucosa (mg/dL)</label>
+        <input type="number" step="any" min="0" class="form-control" name="glucose" value="{{ form_values.get('glucose','') }}">
+      </div>
+      <div class="mb-3">
+        <label for="notes" class="form-label">Hallazgos clínicos</label>
+        <textarea id="notes" class="form-control" name="notes" rows="3">{{ form_values.get('notes','') }}</textarea>
+      </div>
+      <button type="submit" class="btn btn-primary">Calcular</button>
+      {% if ai_active %}
+      <span class="badge bg-info ms-2">IA activa</span>
+      {% else %}
+      <span class="badge bg-secondary ms-2">IA opcional</span>
+      {% endif %}
+    </form>
+  </div>
+  <div class="col-md-6">
+    {% if result %}
+    <div class="d-flex flex-column align-items-center">
+      <div class="progress-circle my-3" style="--value:{{ result.percent }}; --color:{{ result.color_hex }}">
+        <div class="fs-3">{{ result.percent }}%</div>
+      </div>
+      <span class="badge bg-{{ result.color_class }}">{{ result.level }}</span>
+      {% if model == 'lrinec' %}
+      <p class="mt-2">Puntuación LRINEC: {{ lrinec_score }} ({{ lrinec_level }})</p>
+      {% endif %}
+      <ul class="list-unstyled mt-2">
+        {% for k,v in result.inputs.items() %}
+        <li><strong>{{ k }}:</strong> {{ v }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% else %}
+    <img src="{{ url_for('static', filename='img/hero.svg') }}" class="img-fluid" alt="Decoración">
+    {% endif %}
+  </div>
+</div>
+<script>
+function toggleFields(){
+  const model = document.getElementById('model').value;
+  document.querySelectorAll('.demo-field').forEach(el => el.style.display = model==='demo' ? 'block':'none');
+  document.querySelectorAll('.lrinec-field').forEach(el => el.style.display = model==='lrinec' ? 'block':'none');
+}
+window.addEventListener('load', toggleFields);
+document.getElementById('model').addEventListener('change', toggleFields);
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Flask app with DEMO and LRINEC risk calculators
- integrate optional OpenAI text factor and keyword fallback
- responsive Bootstrap UI with progress circle and educational disclaimers

## Testing
- `python -m py_compile fascitis-app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689a605421a88325a97424c4da83eb4a